### PR TITLE
Fixes after log4j upgrade

### DIFF
--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -34,11 +34,6 @@
             <artifactId>log4j-core</artifactId>
             <version>2.17.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>
     </dependencies>
 
 

--- a/Common/src/main/java/uk/ac/ebi/cheminformatics/pks/annotation/CladeAnnotationFactory.java
+++ b/Common/src/main/java/uk/ac/ebi/cheminformatics/pks/annotation/CladeAnnotationFactory.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.cheminformatics.pks.annotation;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
+import org.apache.logging.log4j.Logger;
 import runner.RunnerPreferenceField;
 import uk.ac.ebi.cheminformatics.pks.PKSPreferences;
 
@@ -14,7 +15,7 @@ public class CladeAnnotationFactory {
 
     private static CladeAnnotation cladeAnnotation;
     private static final Preferences prefs = Preferences.userNodeForPackage(PKSPreferences.class);
-    private static final Logger LOGGER = Logger.getLogger(CladeAnnotationFactory.class);
+    private static final Logger LOGGER = LogManager.getLogger(CladeAnnotationFactory.class);
 
     public static CladeAnnotation getInstance() {
         if(cladeAnnotation == null) {

--- a/Common/src/main/java/uk/ac/ebi/cheminformatics/pks/parser/FeatureFileConcatenator.java
+++ b/Common/src/main/java/uk/ac/ebi/cheminformatics/pks/parser/FeatureFileConcatenator.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.cheminformatics.pks.parser;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 
 import java.io.*;
 import java.nio.file.Path;
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class FeatureFileConcatenator {
 
-    private static final Logger LOGGER = Logger.getLogger(FeatureFileConcatenator.class);
+    private static final Logger LOGGER = LogManager.getLogger(FeatureFileConcatenator.class);
 
     private Path concatenatedPath;
 

--- a/PKSPredictorREST/pom.xml
+++ b/PKSPredictorREST/pom.xml
@@ -62,11 +62,6 @@
             <version>2.17.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-web-api</artifactId>
             <version>7.0</version>

--- a/PKSPredictorREST/src/main/java/prediction/PKSStructureImageDataRes.java
+++ b/PKSPredictorREST/src/main/java/prediction/PKSStructureImageDataRes.java
@@ -1,7 +1,7 @@
 package prediction;
 
 import encrypt.Encrypter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import org.openscience.cdk.exception.CDKException;
 import org.restlet.data.MediaType;
 import org.restlet.representation.FileRepresentation;
@@ -22,7 +22,7 @@ import java.io.IOException;
 
 public class PKSStructureImageDataRes extends ServerResource {
 
-    private static final Logger LOGGER = Logger.getLogger(PKSStructureImageDataRes.class);
+    private static final Logger LOGGER = LogManager.getLogger(PKSStructureImageDataRes.class);
 
     @Get("png")
     public Representation represent() {

--- a/PKSPredictorREST/src/main/java/prediction/PKSStructureSmilesDataRes.java
+++ b/PKSPredictorREST/src/main/java/prediction/PKSStructureSmilesDataRes.java
@@ -1,7 +1,7 @@
 package prediction;
 
 import encrypt.Encrypter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.restlet.representation.Representation;
@@ -17,7 +17,7 @@ import java.io.File;
 
 public class PKSStructureSmilesDataRes extends ServerResource {
 
-    private static final Logger LOGGER = Logger.getLogger(PKSStructureSmilesDataRes.class);
+    private static final Logger LOGGER = LogManager.getLogger(PKSStructureSmilesDataRes.class);
 
     @Get("xml")
     public Representation represent() {

--- a/PKSPredictorREST/src/main/java/router/PKSRouter.java
+++ b/PKSPredictorREST/src/main/java/router/PKSRouter.java
@@ -1,6 +1,6 @@
 package router;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import org.restlet.Application;
 import org.restlet.Restlet;
 import org.restlet.routing.Router;
@@ -10,7 +10,7 @@ import prediction.PKSStructureSmilesDataRes;
 
 public class PKSRouter extends Application {
 
-    private static final Logger LOGGER = Logger.getLogger(PKSRouter.class);
+    private static final Logger LOGGER = LogManager.getLogger(PKSRouter.class);
 
     /**
      * Creates a root Restlet that will receive all incoming calls.

--- a/PKSPredictorRunner/pom.xml
+++ b/PKSPredictorRunner/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>log4j-core</artifactId>
             <version>2.17.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>        
     </dependencies>
 
 </project>

--- a/PKSPredictorRunner/src/main/java/runner/PKSPredictor.java
+++ b/PKSPredictorRunner/src/main/java/runner/PKSPredictor.java
@@ -1,6 +1,6 @@
 package runner;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import uk.ac.ebi.cheminformatics.pks.PKSPreferences;
 
 import java.io.*;
@@ -11,7 +11,7 @@ import java.util.prefs.Preferences;
 
 public class PKSPredictor implements Runnable {
 
-    private static final Logger LOGGER = Logger.getLogger(PKSPredictor.class);
+    private static final Logger LOGGER = LogManager.getLogger(PKSPredictor.class);
 
     private Preferences prefs;
     private String command;

--- a/PKSPredictorWeb/pom.xml
+++ b/PKSPredictorWeb/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.biojava</groupId>
             <artifactId>biojava-core</artifactId>
-            <version>4.2.7</version>
+            <version>6.0.5</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/PKStructureGenerator/pom.xml
+++ b/PKStructureGenerator/pom.xml
@@ -52,11 +52,6 @@
             <version>2.17.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.openscience.cdk</groupId>
             <artifactId>cdk-sdg</artifactId>
             <version>${cdk.version}</version>

--- a/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/generator/PKSAssembler.java
+++ b/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/generator/PKSAssembler.java
@@ -1,7 +1,7 @@
 package uk.ac.ebi.cheminformatics.pks.generator;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -25,7 +25,7 @@ import static com.google.common.collect.ImmutableSet.of;
  */
 public class PKSAssembler {
 
-    private static final Logger LOGGER = Logger.getLogger(PKSAssembler.class);
+    private static final Logger LOGGER = LogManager.getLogger(PKSAssembler.class);
 
     private PKStructure structure;
 

--- a/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/monomer/NRPSMonomerProcessor.java
+++ b/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/monomer/NRPSMonomerProcessor.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.cheminformatics.pks.monomer;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -11,7 +11,7 @@ import uk.ac.ebi.cheminformatics.pks.io.StructureLoader;
 
 public class NRPSMonomerProcessor implements MonomerProcessor {
 
-    static final Logger LOGGER = Logger.getLogger(NRPSMonomerProcessor.class);
+    static final Logger LOGGER = LogManager.getLogger(NRPSMonomerProcessor.class);
     String aminoAcid;
 
     public NRPSMonomerProcessor(String aminoAcid) {

--- a/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/monomer/PKMonomer.java
+++ b/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/monomer/PKMonomer.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.cheminformatics.pks.monomer;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
@@ -21,7 +21,7 @@ import java.util.Set;
 
 public class PKMonomer {
 
-    private static final Logger LOGGER = Logger.getLogger(PKMonomer.class);
+    private static final Logger LOGGER = LogManager.getLogger(PKMonomer.class);
 
     private IAtom preConnectionAtom;
     private IBond preConnectionBond;

--- a/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/parser/FeatureParser.java
+++ b/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/parser/FeatureParser.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.cheminformatics.pks.parser;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import uk.ac.ebi.cheminformatics.pks.sequence.feature.SequenceFeature;
 import uk.ac.ebi.cheminformatics.pks.sequence.feature.SequenceFeatureFactory;
 
@@ -17,7 +17,7 @@ import static java.util.stream.Collectors.toList;
  **/
 public final class FeatureParser {
 
-    private static final Logger LOGGER = Logger.getLogger(FeatureParser.class);
+    private static final Logger LOGGER = LogManager.getLogger(FeatureParser.class);
 
     public static List<SequenceFeature> parse(Path featuresFile) {
         try (Stream<String> stream = Files.lines(featuresFile)) {

--- a/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/parser/FeatureSelection.java
+++ b/PKStructureGenerator/src/main/java/uk/ac/ebi/cheminformatics/pks/parser/FeatureSelection.java
@@ -1,7 +1,7 @@
 package uk.ac.ebi.cheminformatics.pks.parser;
 
 import clustering.DBSCANClusterer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import uk.ac.ebi.cheminformatics.pks.generator.DistanceMetricSequenceFeatures;
 import uk.ac.ebi.cheminformatics.pks.sequence.feature.SequenceFeature;
 
@@ -16,7 +16,7 @@ import static uk.ac.ebi.cheminformatics.pks.sequence.feature.SequenceFeatureFact
 
 public final class FeatureSelection {
 
-    private static final Logger LOGGER = Logger.getLogger(FeatureSelection.class);
+    private static final Logger LOGGER = LogManager.getLogger(FeatureSelection.class);
 
     public static Stream<SequenceFeature> bestMatchCascade(Stream<SequenceFeature> features, int cascadeHeight) {
         return bestMatchCascade(features, cascadeHeight, 5, 20);

--- a/PKStructureGenerator/src/test/java/uk/ac/ebi/cheminformatics/pks/generator/StructureGeneratorTest.java
+++ b/PKStructureGenerator/src/test/java/uk/ac/ebi/cheminformatics/pks/generator/StructureGeneratorTest.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.cheminformatics.pks.generator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.*;
 import org.junit.Test;
 import org.openscience.cdk.io.MDLV2000Writer;
 
@@ -13,7 +13,7 @@ import java.nio.file.Paths;
 
 public class StructureGeneratorTest {
 
-    private static final Logger LOGGER = Logger.getLogger(PKStructure.class);
+    private static final Logger LOGGER = LogManager.getLogger(PKStructure.class);
 
     @Test
     public void testGetStructure() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+            </plugin>
         </plugins>
     </build>
 
@@ -38,21 +43,21 @@
         <repository>
             <id>maven-restlet</id>
             <name>Public online Restlet repository</name>
-            <url>http://maven.restlet.org</url>
+            <url>https://maven.restlet.org</url>
         </repository>
         <repository>
             <id>maven-repo</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
         </repository>
         <repository>
             <id>ebi-repo</id>
             <name>EBI maven repository</name>
-            <url>http://www.ebi.ac.uk/~maven/m2repo</url>
+            <url>https://www.ebi.ac.uk/~maven/m2repo</url>
         </repository>
         <repository>
             <id>ebi-repo-snapshots</id>
             <name>EBI maven snapshots repository</name>
-            <url>http://www.ebi.ac.uk/~maven/m2repo_snapshots</url>
+            <url>https://www.ebi.ac.uk/~maven/m2repo_snapshots</url>
         </repository>
         <repository>
             <id>sonatype</id>
@@ -65,9 +70,7 @@
         <repository>
             <id>ambit-plovdiv</id>
             <name>ambit-plovdiv</name>
-            <url>
-                http://ambit.uni-plovdiv.bg:8083/nexus/content/repositories/thirdparty/
-            </url>
+            <url>https://ambit.uni-plovdiv.bg:8083/nexus/content/repositories/thirdparty/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
Upgraded biojava-core to the latest version to fix the error page when clicking on the example on the main page. Cherrypicked the Uwe's change "upgrade log4j" from the release branch. Other fixes and improvements.